### PR TITLE
Add request timeouts

### DIFF
--- a/aubreylib/system.py
+++ b/aubreylib/system.py
@@ -1,5 +1,4 @@
 import urlparse
-import httplib
 import os
 import re
 import urllib
@@ -54,16 +53,16 @@ def get_file_system(meta_id, file_path, location_tuple):
                 # Quote the url path (helps with spaces and special characters)
                 path = urllib.quote(raw_path)
                 if host != '' and path != '':
-                    # use httplib to see if the file exists on the server
-                    http = httplib.HTTP(host)
-                    http.putrequest("HEAD", path)
-                    http.putheader("Host", host)
-                    http.endheaders()
-                    errcode, errmsg, headers = http.getreply()
+                    # Check if file exists on the server
+                    url = '%s://%s%s' % (scheme, host, path)
+                    headers = {'Host': host}
+                    request = urllib2.Request(url, headers=headers)
+                    request.get_method = lambda: 'HEAD'
+                    status_code = urllib2.urlopen(request, timeout=3).getcode()
                 else:
                     system_path = None
                 # if the file exists, return the necessary data
-                if errcode == 200:
+                if status_code == 200:
                     system_path = '%s://%s%s' % (scheme, host, path)
                     file_location = file_system
                     break

--- a/aubreylib/system.py
+++ b/aubreylib/system.py
@@ -196,7 +196,7 @@ def get_other_system(failed_url):
         replacement_host = urlparse.urlsplit(metadata_location)[1]
         new_url = failed_url.replace(host, replacement_host)
         try:
-            return urllib2.urlopen(new_url)
+            return urllib2.urlopen(new_url, timeout=3)
         except:
             pass
     raise SystemMethodsException("Can't locate file: %s" % (failed_url))

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -34,10 +34,10 @@ class TestGetFileSystem():
         assert (path, location) == expected
 
     @mock.patch('os.path.exists')
-    @mock.patch('httplib.HTTP')
-    def test_file_at_http_url(self, MockedHTTP, mocked_exists):
+    @mock.patch('urllib2.urlopen')
+    def test_file_at_http_url(self, mocked_urlopen, mocked_exists):
         """Locate a file on another server via http URL."""
-        MockedHTTP.return_value.getreply.return_value = (200, '', '')
+        mocked_urlopen.return_value.getcode.return_value = 200
         mocked_exists.return_value = False
         path, location = system.get_file_system('metapthx',
                                                 '/me/ta/pt/hx/metapthx/web/4.jpg',
@@ -47,12 +47,12 @@ class TestGetFileSystem():
         assert (path, location) == expected
 
     @mock.patch('os.path.exists')
-    @mock.patch('httplib.HTTP')
-    def test_file_at_https_url(self, MockedHTTP, mocked_exists):
+    @mock.patch('urllib2.urlopen')
+    def test_file_at_https_url(self, mocked_urlopen, mocked_exists):
         """Locate a file on another server via https URL."""
         # Respond with Success for location_tuple https URL only.
-        http_responses = [(404, '', ''), (404, '', ''), (200, '', '')]
-        MockedHTTP.return_value.getreply.side_effect = http_responses
+        http_responses = [404, 404, 200]
+        mocked_urlopen.return_value.getcode.side_effect = http_responses
         mocked_exists.return_value = False
         path, location = system.get_file_system('metapthx',
                                                 '/me/ta/pt/hx/metapthx/web/4.jpg',
@@ -62,12 +62,12 @@ class TestGetFileSystem():
         assert (path, location) == expected
 
     @mock.patch('os.path.exists')
-    @mock.patch('httplib.HTTP')
-    def test_file_at_http_with_file_in_path(self, MockedHTTP, mocked_exists):
+    @mock.patch('urllib2.urlopen')
+    def test_file_at_http_with_file_in_path(self, mocked_urlopen, mocked_exists):
         """Locate a file on another server via http URL when file path
         starts with 'file://'.
         """
-        MockedHTTP.return_value.getreply.return_value = (200, '', '')
+        mocked_urlopen.return_value.getcode.return_value = 200
         mocked_exists.return_value = False
         path, location = system.get_file_system('metapthx',
                                                 'file://web/4.jpg',
@@ -77,12 +77,12 @@ class TestGetFileSystem():
         assert (path, location) == expected
 
     @mock.patch('os.path.exists')
-    @mock.patch('httplib.HTTP')
-    def test_file_system_with_empty_path(self, MockedHTTP, mocked_exists):
+    @mock.patch('urllib2.urlopen')
+    def test_file_system_with_empty_path(self, mocked_urlopen, mocked_exists):
         """Test http:// location with an '' (empty) `path`."""
         # Respond with Not Found for the first location_tuple URL tried,
         # so the URL with no path will be tried.
-        MockedHTTP.return_value.getreply.return_value = (404, '', '')
+        mocked_urlopen.return_value.getcode.return_value = 404
         mocked_exists.return_value = False
         path, location = system.get_file_system('metapthx',
                                                 '',
@@ -91,10 +91,10 @@ class TestGetFileSystem():
         assert (path, location) == expected
 
     @mock.patch('os.path.exists')
-    @mock.patch('httplib.HTTP')
-    def test_file_not_found(self, MockedHTTP, mocked_exists):
+    @mock.patch('urllib2.urlopen')
+    def test_file_not_found(self, mocked_urlopen, mocked_exists):
         """Test file not found on any given system."""
-        MockedHTTP.return_value.getreply.return_value = (404, '', '')
+        mocked_urlopen.return_value.getcode.return_value = 404
         mocked_exists.return_value = False
         path, location = system.get_file_system('metapthx',
                                                 'web/4.jpg',

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -241,4 +241,4 @@ class TestGetOtherSystem():
         mocked_urlopen.return_value = expected = 'file'
         file_obj = system.get_other_system('http://example.com/disk1/noexist')
         assert file_obj == expected
-        mocked_urlopen.assert_called_once_with('http://url.com/disk1/noexist')
+        mocked_urlopen.assert_called_once_with('http://url.com/disk1/noexist', timeout=3)


### PR DESCRIPTION
This is to help prevent systems choking when one of our metadata or static file servers goes down. Previously there was no timeout on requests and instead of cycling to the next possible server when one was down things would hang and cause backlog of requests.

ping @somexpert @vphill @jason-ellis @jthomale 
